### PR TITLE
Fix 20

### DIFF
--- a/juju_docean/constraints.py
+++ b/juju_docean/constraints.py
@@ -20,8 +20,6 @@ for s in SIZE_MAP.values():
 
 SIZES_SORTED = (66, 63, 62, 64, 65, 61, 60, 70, 69, 68)
 
-
-
 IMAGE_MAP = {
     'precise': 3100616,
     '12.04': 3100616,


### PR DESCRIPTION
Fixes #20 caused by invalid image id's being in the map.

This is just a bandaid however, a smarter way to do this would be to do some exact matching on the API output, as their images are going to be deprecated at random times whenever they decide to release a new image id. I'll brain bend around how to do this and see about a follow up feature branch with it.
