### PR TITLE
Added support for digitalocean api v2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,11 +58,16 @@ A digital ocean account is a pre-requisite, If you don't have a
 digital ocean account you can sign up `here`_.
 
 Credentials for the digital ocean api can be obtained from your account
-dashboard at https://cloud.digitalocean.com/api_access
+dashboard at https://cloud.digitalocean.com/settings/applications
 
-The credentials can be provided to the plugin via.
+The credentials can be provided to the plugin via:
 
-  - Environment variables DO_CLIENT_ID and DO_API_KEY
+- Environment variable DO_OAUTH_TOKEN
+
+If you're using an older version of juju-docean, it still accepts the
+digitalocean api v1 credentials via:
+
+- Environment variables DO_CLIENT_ID and DO_API_KEY
 
 This digital ocean plugin uses the manual provisioning capabilities of
 juju core. As a result its required to allocate machines in the
@@ -209,18 +214,18 @@ criteria.
 
 This plugin accepts the standard `juju constraints`_
 
-  - cpu-cores
-  - memory
-  - root-disk
+- cpu-cores
+- memory
+- root-disk
 
 Additionally it supports the following provider specific constraints.
 
-  - 'region' to denote the digital ocean data center to utilize. All digitalocean
-    data centers are supported and various short hand aliases are defined. ie. valid
-    values include ams2, nyc1, nyc2, sfo1, sg1. The plugin defaults to nyc2.
+- 'region' to denote the digital ocean data center to utilize. All digitalocean
+  data centers are supported and various short hand aliases are defined. ie. valid
+  values include ams2, nyc1, nyc2, sfo1, sg1. The plugin defaults to nyc3.
 
-  - 'transfer' to denote the terabytes of transfer included in the
-    instance montly cost (integer size in gigabytes).
+- 'transfer' to denote the terabytes of transfer included in the
+  instance montly cost (integer size in terabytes).
 
 
 .. _builds: https://travis-ci.org/kapilt/juju-digitalocean/builds

--- a/juju_docean/client.py
+++ b/juju_docean/client.py
@@ -24,52 +24,112 @@ class SSHKey(Entity):
 class Droplet(Entity):
     """Instance on digital ocean.
 
-    Attributes: id, name, size_id, image_id, region_id, event_id,
-    backups_active, status, ip_address, created_at
+    Attributes: id, name, ip_address, created_at, status, size_id, region_id,
+                image_id, event_id
     """
 
 
 class Image(Entity):
     """
-    Attributes:, id, name, distribution, slug, public
+    Attributes: id, slug, name, distribution, public, regions
+    """
+
+
+class Size(Entity):
+    """
+    Attributes: id, name, slug, memory (mb), cpus, disk (gb), transfer (tb),
+                price (/mth), regions (v2 only)
     """
 
 
 class Region(Entity):
     """
-    Attributes: slug, id, name
+    Attributes: id, slug, name, sizes (v2 only), features (v2 only)
     """
 
 
 class Client(object):
+
+    def get_url(self, target):
+        if target.startswith('/'):
+            return "%s%s" % (self.api_url_base, target)
+        assert target.startswith('https://')
+        return target
+
+    def get_sizes(self):
+        data = self.request("/sizes")
+        return filter(None, map(self.make_size, data.get('sizes', [])))
+
+    def get_regions(self):
+        data = self.request("/regions")
+        return filter(None, map(self.make_region, data.get("regions", [])))
+
+    def get_images(self):
+        data = self.request("/images")
+        return filter(None, map(self.make_image, data.get("images", [])))
+
+    def get_droplets(self):
+        data = self.request("/droplets")
+        return map(self.make_droplet, data.get('droplets', []))
+
+    def get_droplet(self, droplet_id):
+        data = self.request("/droplets/%s" % droplet_id)
+        return self.make_droplet(data.get('droplet', {}))
+
+    @classmethod
+    def connect(cls, config=os.environ):
+        client_id = config.get('DO_CLIENT_ID')
+        key = config.get('DO_API_KEY')
+        if client_id or key:
+            if not client_id or not key:
+                raise KeyError("Missing api credentials")
+            return Client_v1(client_id, key)
+        oauth_token = config.get('DO_OAUTH_TOKEN')
+        if not oauth_token:
+            raise KeyError("Missing api credentials")
+        return Client_v2(oauth_token)
+
+
+class Client_v1(Client):
+    Transfers_for_sizes = {'512mb': 1, '1gb': 2, '2gb': 3, '4gb': 4, '8gb': 5,
+                           '16gb': 6, '32gb': 7, '48gb': 8, '64gb': 9, 
+                          }
 
     def __init__(self, client_id, api_key):
         self.client_id = client_id
         self.api_key = api_key
         self.api_url_base = 'https://api.digitalocean.com/v1'
 
-    def get_images(self, filter="global"):
-        data = self.request("/images")
-        return map(Image.from_dict, data.get("images", []))
-
-    def get_url(self, target):
-        return "%s%s" % (self.api_url_base, target)
-
     def get_ssh_keys(self):
         data = self.request("/ssh_keys")
         return map(SSHKey.from_dict, data.get('ssh_keys', []))
 
-    def get_droplets(self):
-        data = self.request("/droplets")
-        return map(Droplet.from_dict, data.get('droplets', []))
+    def make_image(self, info):
+        return Image.from_dict(
+                 dict(id=info['id'], slug=info['slug'], name=info['name'],
+                      distribution=info['distribution'], public=info['public'],
+                      regions=info['region_slugs']))
 
-    def get_droplet(self, droplet_id):
-        data = self.request("/droplets/%s" % (droplet_id))
-        return Droplet.from_dict(data.get('droplet', {}))
+    def make_region(self, info):
+        return Region.from_dict(
+                 dict(id=info['id'], name=info['name'], slug=info['slug']))
 
-    def get_regions(self):
-        data = self.request("/regions")
-        return map(Region.from_dict, data.get("regions", []))
+    def make_size(self, info):
+        return Size.from_dict(
+                 dict(id=info['id'], name=info['name'], slug=info['slug'],
+                      memory=info['memory'],
+                      cpus=info['cpu'], disk=info['disk'],
+                      transfer=self.Transfers_for_sizes[info['slug']],
+                      price=float(info['cost_per_month'])))
+
+    def make_droplet(self, info):
+        attributes = dict(id=info['id'], name=info['name'], 
+                          image_id=info['image_id'], size_id=info['size_id'])
+        for name in ('event_id', 'ip_address', 'created_at', 'status',
+                     'region_id', 'event_id'):
+            if name in info:
+                attributes[name] = info[name]
+        return Droplet.from_dict(attributes)
 
     def create_droplet(self, name, size_id, image_id, region_id,
                        ssh_key_ids=None, private_networking=False,
@@ -84,7 +144,15 @@ class Client(object):
         if ssh_key_ids:
             params['ssh_key_ids'] = ','.join(ssh_key_ids)
         data = self.request('/droplets/new', params=params)
-        return Droplet.from_dict(data.get('droplet', {}))
+        return self.make_droplet(data.get('droplet', {}))
+
+    def create_done(self, event_id, name):
+        data = self.request('/events/%s' % event_id)
+        event = data.get('event', {})
+        if event.get('event_type_id', 1) != 1:
+            raise ValueError("Waiting on invalid event type: %d for %s" %
+                               (event['event_type_id'], name))
+        return event.get('action_status') == 'done', data
 
     def destroy_droplet(self, droplet_id, scrub=True):
         data = self.request(
@@ -116,13 +184,109 @@ class Client(object):
 
         return data
 
-    @classmethod
-    def connect(cls):
-        client_id = os.environ.get('DO_CLIENT_ID')
-        key = os.environ.get('DO_API_KEY')
-        if not client_id or not key:
-            raise KeyError("Missing api credentials")
-        return cls(client_id, key)
+
+class Client_v2(Client):
+
+    def __init__(self, oauth_token):
+        self.oauth_token = oauth_token
+        self.api_url_base = 'https://api.digitalocean.com/v2'
+
+    def get_ssh_keys(self):
+        data = self.request("/account/keys")
+        return map(self.make_ssh_key, data.get('ssh_keys', []))
+
+    def make_ssh_key(self, info):
+        return SSHKey.from_dict(
+                 dict(id=info['id'], name=info['name']))
+
+    def make_image(self, info):
+        return Image.from_dict(
+                 dict(id=info['id'], slug=info['slug'], name=info['name'],
+                      distribution=info['distribution'], public=info['public'],
+                      regions=info['regions']))
+
+    def make_region(self, info):
+        if info['available']:
+            return Region.from_dict(
+                     dict(id=info['slug'], name=info['name'], slug=info['slug'],
+                          sizes=info['sizes'], features=info['features']))
+
+    def make_size(self, info):
+        if info['available']:
+            return Size.from_dict(
+                     dict(id=info['slug'], name=info['slug'], slug=info['slug'],
+                          memory=info['memory'],
+                          cpus=info['vcpus'], disk=info['disk'],
+                          transfer=info['transfer'],
+                          price=info['price_monthly'],
+                          regions=info['regions']))
+
+    def make_droplet(self, info):
+        attributes = dict(id=info['id'], name=info['name'], 
+                          status=info['status'], size_id=info['size_slug'],
+                          created_at=info['created_at'])
+        if 'v4' in info['networks']:
+            for network in info['networks']['v4']:
+                if network['type'] == 'public':
+                    attributes['ip_address'] = network['ip_address']
+                    break
+        if 'slug' in info['region']:
+            attributes['region_id'] = info['region']['slug']
+        if 'id' in info['image']:
+            attributes['image_id'] = info['image']['id']
+        return Droplet.from_dict(attributes)
+
+    def create_droplet(self, name, size_id, image_id, region_id,
+                       ssh_key_ids=None, private_networking=False,
+                       backups_enabled=False, virtio=True):
+        params = dict(
+            name=name, size=size_id,
+            image=image_id, region=region_id,
+            private_networking=bool(private_networking),
+            backups=bool(backups_enabled))
+
+        if ssh_key_ids:
+            params['ssh_keys'] = ssh_key_ids
+        data = self.request('/droplets', 'POST', data=params)
+        ans = self.make_droplet(data.get('droplet', {}))
+        for action in data.get('links', {}).get('actions', []):
+            ans.event_id = action['href']
+        return ans
+
+    def create_done(self, event_id, name):
+        data = self.request(event_id)
+        event = data.get('action', {})
+        if event.get('type', 'create') != 'create':
+            raise ValueError("Waiting on invalid action type: %s for %s" %
+                               (event['type'], name))
+        completed = event.get('status') == 'completed'
+        return completed, event
+
+    def destroy_droplet(self, droplet_id, scrub=True):
+        self.request("/droplets/%s" % droplet_id, 'DELETE')
+
+    def request(self, target, method='GET', params=None, data=None):
+        p = params and dict(params) or {}
+        p['per_page'] = 1000
+
+        headers = {'User-Agent': 'juju/client',
+                   'Authorization': 'Bearer ' + self.oauth_token}
+        url = self.get_url(target)
+
+        if data is not None:
+            response = requests.request(method, url, headers=headers, params=p,
+                                        json=data)
+        else:
+            response = requests.request(method, url, headers=headers, params=p)
+
+        if not (200 <= response.status_code < 300):
+            raise ProviderAPIError(response, response.json())
+
+        if method.lower() != 'delete':
+            data = response.json()
+            if not data:
+                raise ProviderAPIError(response, 'No json result found')
+            return data
 
 
 def main():

--- a/juju_docean/commands.py
+++ b/juju_docean/commands.py
@@ -120,18 +120,23 @@ class ListMachines(BaseCommand):
                 header = None
 
             for r in constraints.REGIONS:
-                if m.region_id == r['id']:
+                if m.region_id == r.id:
                     break
             name = m.name
             if len(name) > 18:
                 name = name[:15] + "..."
+            size = constraints.SIZE_MAP.get(m.size_id)
+            if size is None:
+                size_name = "Unknown"
+            else:
+                size_name = getattr(size, 'name', "Unknown")
             print("{:<8} {:<18} {:<5} {:<8} {:<12} {:<6} {:<10}".format(
                 m.id,
                 name,
-                constraints.SIZE_MAP.get(m.size_id, {}).get('name', "Unknown"),
+                size_name,
                 m.status,
                 m.created_at[:-10],
-                r['aliases'][0],
+                r.slug,
                 m.ip_address).strip())
 
 

--- a/juju_docean/constraints.py
+++ b/juju_docean/constraints.py
@@ -1,44 +1,9 @@
 from juju_docean.exceptions import ConstraintError
 
-# Record sizes so we can offer constraints around disk, cpu and transfer,
-# The v1 api only gives a name (based on ram size) and id.
-SIZE_MAP = {
-    60: {'name': '32GB', 'mem': 1024*32, 'disk': 320, 'xfer': 7, 'cpu': 12},
-    61: {'name': '16GB', 'mem': 1024*16, 'disk': 160, 'xfer': 6, 'cpu': 8},
-    62: {'name': '2GB', 'mem': 1024*2, 'disk': 40, 'xfer': 3, 'cpu': 2},
-    63: {'name': '1GB', 'mem': 1024, 'disk': 30, 'xfer': 2, 'cpu': 1},
-    64: {'name': '4GB', 'mem': 1024*4, 'disk': 60, 'xfer': 4, 'cpu': 2},
-    65: {'name': '8GB', 'mem': 1024*8, 'disk': 80, 'xfer': 5, 'cpu': 4},
-    66: {'name': '512MB', 'mem': 512, 'disk': 20, 'xfer': 1, 'cpu': 1},
-    68: {'name': '96GB', 'mem': 1024*96, 'disk': 960, 'xfer': 10, 'cpu': 24},
-    69: {'name': '64GB', 'mem': 1024*64, 'disk': 640, 'xfer': 2, 'cpu': 20},
-    70: {'name': '48GB', 'mem': 1024*48, 'disk': 480, 'xfer': 2, 'cpu': 16}}
-
-# Resize disks to mb (silly default in juju-core)
-for s in SIZE_MAP.values():
-    s['disk'] = s['disk'] * 1024
-
-SIZES_SORTED = (66, 63, 62, 64, 65, 61, 60, 70, 69, 68)
-
 # Would be nice to use ubuntu-distro-info, but portability.
 SERIES_MAP = {
     '12-04': 'precise',
     '14-04': 'trusty'}
-
-
-# Record regions so we can offer nice aliases.
-REGIONS = [
-    {'name': 'New York 1', 'aliases': ['nyc1', 'nyc'], 'id': 1},
-    {'name': 'San Francisco 1', 'aliases': ['sfo1', 'sfo'], 'id': 3},
-    {'name': 'New York 2', 'aliases': ['nyc2'], 'id': 4},
-    {'name': 'Amsterdam 2', 'aliases': ['ams2', 'ams'], 'id': 5},
-    {'name': 'Singapore 1', 'aliases': ['sgp1', 'sgp', 'sg'], 'id': 6},
-    {'name': 'London 1', 'aliases': ['lon1', 'lon', 'london'], 'id': 7},
-    {'name': 'New York 3', 'aliases': ['nyc3'], 'id': 8}]
-
-
-DEFAULT_REGION = 8
-
 
 ARCHES = ['amd64']
 
@@ -51,6 +16,30 @@ SUFFIX_SIZES = {
     "g": 1024,
     "t": 1024 * 1024,
     "p": 1024 * 1024 * 1024}
+
+
+def init(client):
+    global SIZE_MAP, SIZES_SORTED, REGIONS, DEFAULT_REGION
+
+    # Record sizes so we can offer constraints around disk, cpu and transfer.
+    SIZE_MAP = dict((size.id, size) for size in client.get_sizes())
+
+    # Resize disks to mb (silly default in juju-core)
+    for s in SIZE_MAP.values():
+        s.disk *= 1024
+
+    SIZES_SORTED = tuple(sorted(SIZE_MAP.keys(),
+                                key=lambda id: SIZE_MAP[id].price))
+
+    # Record regions so we can offer nice aliases.
+    REGIONS = client.get_regions()
+
+    for region in REGIONS:
+        if region.slug == 'nyc3':
+            DEFAULT_REGION = region.id
+            break
+    else:
+        raise ValueError("Could not find region 'nyc3'")
 
 
 def converted_size(s):
@@ -83,7 +72,7 @@ def parse_constraints(constraints):
         q = converted_size(c['mem'])
         if q is None:
             raise ConstraintError("Invalid memory size %s" % c['mem'])
-        c['mem'] = q
+        c['memory'] = q
 
     if 'root-disk' in c:
         d = c.pop('root-disk')
@@ -96,13 +85,13 @@ def parse_constraints(constraints):
         d = c.pop('transfer')
         if not d.isdigit():
             raise ConstraintError("Unknown transfer size %s" % d)
-        c['xfer'] = int(d)
+        c['transfer'] = int(d)
 
     if 'cpu-cores' in c:
         d = c.pop('cpu-cores')
         if not d.isdigit():
             raise ConstraintError("Unknown cpu-cores size %s" % d)
-        c['cpu'] = int(d)
+        c['cpus'] = int(d)
 
     if 'arch' in c:
         d = c.pop('arch')
@@ -113,9 +102,11 @@ def parse_constraints(constraints):
         for r in REGIONS:
             if c['region'] == r['name']:
                 c['region'] = r['id']
-            elif c['region'] in r['aliases']:
+                break
+            elif c['region'] == r['slug']:
                 c['region'] = r['id']
-        if not isinstance(c['region'], int):
+                break
+        else:
             raise ConstraintError("Unknown region %s" % c['region'])
     return c
 
@@ -133,7 +124,7 @@ def solve_constraints(constraints):
         s_info = SIZE_MAP[s]
         matched = True
         for k, v in constraints.items():
-            if not s_info.get(k) >= v:
+            if not getattr(s_info, k) >= v:
                 matched = False
         if matched:
             return s, region

--- a/juju_docean/constraints.py
+++ b/juju_docean/constraints.py
@@ -68,30 +68,31 @@ def parse_constraints(constraints):
     if unknown:
         raise ConstraintError("Unknown constraints %s" % (" ".join(unknown)))
 
+    c_out = {}
     if 'mem' in c:
         q = converted_size(c['mem'])
         if q is None:
             raise ConstraintError("Invalid memory size %s" % c['mem'])
-        c['memory'] = q
+        c_out['memory'] = q
 
     if 'root-disk' in c:
         d = c.pop('root-disk')
         q = converted_size(d)
         if q is None:
             raise ConstraintError("Unknown root disk size %s" % d)
-        c['disk'] = q
+        c_out['disk'] = q
 
     if 'transfer' in c:
         d = c.pop('transfer')
         if not d.isdigit():
             raise ConstraintError("Unknown transfer size %s" % d)
-        c['transfer'] = int(d)
+        c_out['transfer'] = int(d)
 
     if 'cpu-cores' in c:
         d = c.pop('cpu-cores')
         if not d.isdigit():
             raise ConstraintError("Unknown cpu-cores size %s" % d)
-        c['cpus'] = int(d)
+        c_out['cpus'] = int(d)
 
     if 'arch' in c:
         d = c.pop('arch')
@@ -100,15 +101,15 @@ def parse_constraints(constraints):
 
     if 'region' in c:
         for r in REGIONS:
-            if c['region'] == r['name']:
-                c['region'] = r['id']
+            if c['region'] == r.name:
+                c_out['region'] = r.id
                 break
-            elif c['region'] == r['slug']:
-                c['region'] = r['id']
+            elif c['region'] == r.slug:
+                c_out['region'] = r.id
                 break
         else:
             raise ConstraintError("Unknown region %s" % c['region'])
-    return c
+    return c_out
 
 
 def solve_constraints(constraints):


### PR DESCRIPTION
This adds support for digitalocean's v2 api, while not breaking current users still using the v1 api.  This should fix the issue https://github.com/kapilt/juju-digitalocean/issues/25.

I've updated the README.rst file, but not the tests.  I also don't have access to the v1 api to test that I didn't break that.  Since I made rather substantial changes, that's a definite possibility.

The code now looks for the DO_CLIENT_ID/DO_API_KEY env vars, or a new DO_OAUTH_TOKEN env var.  Which of these are set determines whether it uses the v1 or v2 api.

I'm still a bit new to both github and git (am more of a mercurial user), so it might be helpful to spell things out a bit more if you need changes made, or whatever.

I've successfully done the "bootstrap", "add-machine", "list-machines", "terminate-machine" and "destroy-environment" commands with v2 running on digitalocean.  Again, somebody else will have to try it on v1.